### PR TITLE
fix: Reset scroll position on navigate

### DIFF
--- a/pages/collection.tsx
+++ b/pages/collection.tsx
@@ -45,6 +45,7 @@ export default function Home({ levers }: { levers: Lever[] }) {
   const [selectedStage, setSelectedStage] = useState(levers[0]);
   const [selectedDomain, setSelectedDomain] = useState(levers[0]);
   const [searchTerm, setSearchTerm] = useState("");
+  const selectedLeverPane = React.useRef<HTMLDivElement>(null);
   const router = useRouter();
   const size = useWindowSize();
   const md = markdown({ html: true });
@@ -66,6 +67,13 @@ export default function Home({ levers }: { levers: Lever[] }) {
       setSelectedLever(levers[0]);
     }
   }, [router.query.lever, levers, size.width]);
+
+  useEffect(() => {
+    if (!selectedLeverPane.current) {
+      return;
+    }
+    selectedLeverPane.current.scrollTop = 0;
+  }, [selectedLever]);
   
   const handleClick = (lever: Lever) => {
     setSelectedLever(lever);
@@ -219,7 +227,10 @@ export default function Home({ levers }: { levers: Lever[] }) {
             </div>
           </div>
         </div>
-        <div className="w-1/2 hidden md:inline-block overflow-y-scroll">
+        <div
+          ref={selectedLeverPane}
+          className="w-1/2 hidden md:inline-block overflow-y-scroll"
+        >
           <img alt="" src={`/${selectedLever?.image}`} className="" />
           <div className="p-8">
             <h2 className="mt-3 my-3">{selectedLever?.title} </h2>


### PR DESCRIPTION
When navigating through Levers the scroll position is errantly maintained—this resets it.

| Before | After |
|-----|-----|
| <video src="https://github.com/ansonyuu/levers/assets/38896593/40d9e3cb-482b-4699-b266-d6f76835713b" controls="controls" style="max-width: 730px;"> </video> | <video src="https://github.com/ansonyuu/levers/assets/38896593/2f59c848-a659-4d80-bde4-5726e62ccf51" controls="controls" style="max-width: 730px;"> </video> |

---

Neat project!
